### PR TITLE
Remove TTY and Interactive flags to fix kubebench

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ node {
     stage "Source Code Static Analysis"
         
     stage "Kubernetes Analysis"
-        sh 'kubectl run --rm -i -t kube-bench-node --image=aquasec/kube-bench:latest --restart=Never --overrides="{ \\"apiVersion\\": \\"v1\\", \\"spec\\": { \\"hostPID\\": true } }" -- node --version 1.8'
+        sh 'kubectl run --rm kube-bench-node --image=aquasec/kube-bench:latest --restart=Never --overrides="{ \\"apiVersion\\": \\"v1\\", \\"spec\\": { \\"hostPID\\": true } }" -- node --version 1.8'
 
     stage "Deploy"
         sh "sed 's#127.0.0.1:30400/link-unshorten:latest#'$BUILDIMG'#' k8s/deployment.yaml | kubectl apply -f -"


### PR DESCRIPTION
Remove TTY and Interactive flags to fix Kube bench runs in Jenkins, as the Jenkins output is not a terminal